### PR TITLE
S14 fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "apex_legends"
 description = "An API wrapper for the MozambiqueHe.re Apex Legends API."
-version = "0.1.3"
+version = "0.1.2"
 edition = "2018"
 author = "KasprDev <kasprdev@gmail.com>"
 repository = "https://github.com/KasprDev/Apex-Legends-API-Rust"

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -14,6 +14,8 @@ pub struct ApexGlobal {
     pub avatar: String,
     pub platform: String,
     pub level: i32,
+    #[serde(alias = "levelPrestige")]
+    pub level_prestige: i32,
     #[serde(alias = "toNextLevelPercent")]
     pub to_next_level_percent: i32,
     pub rank: ApexRank,


### PR DESCRIPTION
> As soon as S14 drops, the level system will be updated in the API.
Level value will be switched to the prestige system. The "level" field will have the current player level, and the "levelPrestige" will have the current player prestige level.<br/>
Example:
Lvl 506 will return level = 6 & levelPrestige = 1
Lvl 167 will return level = 167 & levelPrestige = 0 


Source: [https://discord.com/channels/556094211972136970/852807307033313320/1005869784061198336](https://discord.com/channels/556094211972136970/852807307033313320/1005869784061198336)